### PR TITLE
fix: don't log message when creating uuid.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export const pluginDevtoolsJson = (
 
       const uuid = v4();
       fs.writeFileSync(uuidPath, uuid, { encoding: 'utf-8' });
-      logger.info(
+      logger.debug(
         `[rsbuild-plugin-devtools-json] Generated UUID '${uuid}' for DevTools project settings.`,
       );
       return uuid;


### PR DESCRIPTION
Ref: https://github.com/ChromeDevTools/vite-plugin-devtools-json/commit/930562399c76e3c7ed2ce4c0f509b3098287a475